### PR TITLE
Simplify cli arguments for benchmark definition

### DIFF
--- a/definition/benchmarkdef.go
+++ b/definition/benchmarkdef.go
@@ -53,14 +53,15 @@ type Instruction struct {
 type Instructions []Instruction
 
 type Application struct {
-	Name    string
-	Image   string
-	Type    string
-	Network string
-	Volumes Volumes
-	Ports   []int
-	Args    []string
-	Envs    map[string]string
+	Name         string
+	Image        string
+	Type         string
+	Network      string
+	Volumes      Volumes
+	Ports        []int
+	Args         []string
+	Envs         map[string]string
+	UnitFilePath string `yaml:"unitfile-path"`
 }
 
 type Volumes []Volume
@@ -220,6 +221,23 @@ func parseBenchmarkDef(filePath string) (BenchmarkDef, error) {
 func validateDefinition(benchmark BenchmarkDef) bool {
 	if benchmark.InstanceGroupSize <= 0 {
 		log.Logger().Fatal("instance group size has to be greater or equal to 1")
+	}
+
+	// Validate application definition
+	if benchmark.Application.Type == "" {
+		log.Logger().Errorf("wrong application type %v", benchmark.Application.Type)
+		return false
+	}
+	if benchmark.Application.Type != "unitfiles" || benchmark.Application.Type != "docker" || benchmark.Application.Type != "rkt" {
+		log.Logger().Errorf("wrong application type %v", benchmark.Application.Type)
+		return false
+	}
+	if benchmark.Application.Type == "unitfiles" && benchmark.Application.UnitFilePath == "" {
+		log.Logger().Errorf("application unit file path is required for type %v", benchmark.Application.Type)
+		return false
+	}
+	if benchmark.Application.Image == "" && benchmark.Application.Type == "docker" && benchmark.Application.Type == "rkt" {
+		log.Logger().Warning("application image is empty using standard container")
 	}
 	emptyInstruction := &Instruction{}
 

--- a/definition/benchmarkdef.go
+++ b/definition/benchmarkdef.go
@@ -224,11 +224,7 @@ func validateDefinition(benchmark BenchmarkDef) bool {
 	}
 
 	// Validate application definition
-	if benchmark.Application.Type == "" {
-		log.Logger().Errorf("wrong application type %v", benchmark.Application.Type)
-		return false
-	}
-	if benchmark.Application.Type != "unitfiles" || benchmark.Application.Type != "docker" || benchmark.Application.Type != "rkt" {
+	if benchmark.Application.Type != "" && benchmark.Application.Type != "unitfiles" && benchmark.Application.Type != "docker" && benchmark.Application.Type != "rkt" {
 		log.Logger().Errorf("wrong application type %v", benchmark.Application.Type)
 		return false
 	}

--- a/definition/benchmarkdef_test.go
+++ b/definition/benchmarkdef_test.go
@@ -24,6 +24,13 @@ instructions:
   - stop: stop-all
 `
 
+var dataAppUnitFiles = `
+application:
+ name: helloworld
+ unitfile-path: /tmp/test.service
+ type: unitfiles
+instancegroup-size: 1
+`
 var dataAppTest = `
 application:
  name: helloworld
@@ -203,5 +210,30 @@ func TestApplicationYAMLDefinition(t *testing.T) {
 
 	if len(ins.Application.Volumes) != len(expected.Volumes) || ins.Application.Volumes[1].Source != "/usr/lib/vol2" {
 		log.Fatalf("application volumes is wrong %v expected %v", ins.Application.Volumes, expected.Volumes)
+	}
+}
+
+func TestApplicationUnitFileYAMLDefinition(t *testing.T) {
+	ins := BenchmarkDef{}
+
+	if err := yaml.Unmarshal([]byte(dataAppUnitFiles), &ins); err != nil {
+		log.Fatalf("unable to parse the yaml test definition: %v", err)
+	}
+
+	if ins.InstanceGroupSize != 1 {
+		log.Fatalf("wrong instance group size is wrong %d expected 1", ins.InstanceGroupSize)
+	}
+
+	expected := &Application{
+		Name:         "helloword",
+		UnitFilePath: "/tmp/test.service",
+	}
+
+	if reflect.DeepEqual(ins.Application.Name, expected.Name) {
+		log.Fatalf("application name is wrong %v expected %v", ins.Application.Name, expected.Name)
+	}
+
+	if ins.Application.UnitFilePath != expected.UnitFilePath {
+		log.Fatalf("application unit file path is wrong %v expected %v", ins.Application.UnitFilePath, expected.UnitFilePath)
 	}
 }

--- a/docs/README.md
+++ b/docs/README.md
@@ -24,8 +24,8 @@ In the following, we detail the purpose of each of the elements that composes a 
 - `application`:
   - `name`: name to be used as prefix in our fleet units.
   - `unitfile-path`: path to the custom systemd unit to be used as benchmark application.
-  - `image`: specifies the [docker](https://github.com/docker/docker) image or url to a [rkt](https://github.com/coreos/rkt) container definition. If no container `image` is specified and `type` is `rkt|docker` a default standard image would be used (image or aci based in a simple Linux Alpine image).
-  - `type`: `rkt|docker|unitfiles` types used to specify whether a deployed application would be a [rkt](https://github.com/coreos/rkt), [docker](https://github.com/docker/docker) container or a custom systemd unit.
+  - `image`: specifies the [docker](https://github.com/docker/docker) image or a URL to a [rkt](https://github.com/coreos/rkt) container definition. If no container `image` is specified and `type` is `rkt|docker` a default standard image will be used (image or ACI based on a simple Linux Alpine image).
+  - `type`: `rkt|docker|unitfiles` types used to specify whether a deployed application should be a [rkt](https://github.com/coreos/rkt) container, [docker](https://github.com/docker/docker) container, or a custom systemd unit.
   - `network`: indicates the type of network to be used in our containers `host|none|default`, as analogous to the network types defined in [rkt](https://github.com/coreos/rkt) and [docker](https://github.com/docker/docker).
   - `volumes`: list of volumes to be defined in the container.
     - `source`: path of source of the volume on the host.

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,14 +7,11 @@ Nomi is a benchmarking tool that tests a [fleet](https://github.com/coreos/fleet
 - `--addr`: address to listen events from the deployed units. This argument is **important** to allow units notify Nomi when they change their state. Nomi extracts the public CoreOS IP of the host machine automatically (from `/etc/environment`). Note that you should use this argument when using a different distro than CoreOS, a Docker container, or a different address to listen on. The `default` port to listen on is `40302`.
 - `--dump-json`: dump JSON collected metrics to stdout.
 - `--dump-html-tar`: dump tarred HTML stats to stdout.
-- `--benchmark-file`: YAML file with the actions to be triggered and the size of the instance groups.
-- `--raw-instructions`: benchmark raw instructions to be triggered, (requires the `--instancegroup-size` argument) and the size of the instance groups.
+- `--benchmark-file`: YAML file with a custom benchmark definition to be triggered.
+- `--raw-instructions`: benchmark raw instructions to be triggered, (requires the `--instancegroup-size` argument) and the size of the instance groups. This option will use a default systemd unit as predefined benchmark application.
 - `--instancegroup-size`: size of the instance group in terms of units, (only if you use `raw-instructions`).
 - `--generate-gnuplots`: generate gnuplots out of the collected metrics. It is preferable to use `raw-instructions` instead of `benchmark-file` to avoid specifying a docker volume to pass a YAML benchmark definition.
     - **Important:** You have to run Nomi as a Docker container in your CoreOS machine.
-- `unitfile-service`: fleet unit file of type service to be used as benchmark unit.
-- `use-docker`: use benchmark units that deploy [Docker](https://github.com/docker/docker) containers. If no container image and type is defined in `benchmark-file`, we deploy a standard container that use a simple Linux Alpine image.
-- `use-rkt`: use benchmark units that deploy [rkt](https://github.com/coreos/rkt) containers. If no container image and type is defined in `benchmark-file`, we deploy a standard aci which is based in a simple Linux Alpine image.
 
 ## Benchmark file definition
 
@@ -26,8 +23,9 @@ In the following, we detail the purpose of each of the elements that composes a 
 
 - `application`:
   - `name`: name to be used as prefix in our fleet units.
-  - `image`: specifies the [docker](https://github.com/docker/docker) image or url to a [rkt](https://github.com/coreos/rkt) container definition.
-  - `type`: used to specify whether a deployed container would be [rkt](https://github.com/coreos/rkt) or [docker](https://github.com/docker/docker).
+  - `unitfile-path`: path to the custom systemd unit to be used as benchmark application.
+  - `image`: specifies the [docker](https://github.com/docker/docker) image or url to a [rkt](https://github.com/coreos/rkt) container definition. If no container `image` is specified and `type` is `rkt|docker` a default standard image would be used (image or aci based in a simple Linux Alpine image).
+  - `type`: `rkt|docker|unitfiles` types used to specify whether a deployed application would be a [rkt](https://github.com/coreos/rkt), [docker](https://github.com/docker/docker) container or a custom systemd unit.
   - `network`: indicates the type of network to be used in our containers `host|none|default`, as analogous to the network types defined in [rkt](https://github.com/coreos/rkt) and [docker](https://github.com/docker/docker).
   - `volumes`: list of volumes to be defined in the container.
     - `source`: path of source of the volume on the host.
@@ -94,23 +92,13 @@ The main difference is the input format, in which the instructions are entered. 
 
 ### Executing the Nomi binary
 
-Using a benchmark YAML file to run a test that deploys rkt containers:
+Using a benchmark YAML file to run a test that deploys a custom rkt container:
 
 ```nohighlight
 $ nomi run \
     --instancegroup-size=1 \
     --dump-json \
-    --benchmark-file="./examples/sample01.yaml" \
-    --use-rkt
-```
-
-Using a benchmark YAML file to run a custom rkt container:
-
-```nohighlight
-$ nomi run \
-     --instancegroup-size=1 \
-     --dump-json \
-     --benchmark-file="./examples/benchmarkDefRkt.yaml"
+    --benchmark-file="./examples/benchmarkDefRkt.yaml"
 ```
 
 Using a benchmark that uses a custom fleet unit service's file:
@@ -118,8 +106,7 @@ Using a benchmark that uses a custom fleet unit service's file:
 ```nohighlight
 $ nomi run \
     --dump-json \
-    --benchmark-file="./examples/benchmarkDef01.yaml" \
-    --unitfile-service=./examples/benchmarkDefUnitFile.service
+    --benchmark-file="./examples/benchmarkDefUnitFile.yaml"
 ```
 
 Using `--raw-instructions` and `--instancegroup-size` arguments to run a benchmark that deploys raw systemd units:
@@ -139,7 +126,6 @@ $ ./nomi run \
     --instancegroup-size=1 \
     --dump-json \
     --benchmark-file="./examples/sample01.yaml" \
-    --use-rkt
 ```
 
 ### Running Nomi remotely

--- a/docs/README.md
+++ b/docs/README.md
@@ -86,7 +86,7 @@ instructions:
 
 ### Passing a string with the instructions via `--raw-instructions`
 
-The main difference is the input format, in which the instructions are entered. When using `--raw-instructions`, those are passed in a string fashion , e.g. `--raw-instructions="(sleep 1) (start 200 100) (stop-all)"`. Each parenthesis represents a single instruction that will be executed in sequence and following the inline order. Therefore, a sleep instruction will be followed by a start (with Max: 200 and Duration: 100) and stop operations.
+When using `--raw-instructions`, the instructions are passed in a string fashion and a default systemd unit is used as benchmark application. An example of `raw-instructions` could be `--raw-instructions="(sleep 1) (start 200 100) (stop-all)"`. Each parenthesis represents a single instruction that will be executed in sequence and following the inline order. Therefore, a sleep instruction will be followed by a start (with Max: 200 and Duration: 100) and stop operations.
 
 ## Running Nomi
 

--- a/unit/builder_test.go
+++ b/unit/builder_test.go
@@ -10,13 +10,13 @@ import (
 func TestBuilder(t *testing.T) {
 	// check basic configuration
 	app := definition.Application{}
-	builder, err := NewBuilder(app, 1, "127.0.0.1:54541", false, false)
+	builder, err := NewBuilder(app, 1, "127.0.0.1:54541")
 	if err != nil {
 		log.Fatal(err)
 	}
 	units1 := builder.MakeUnitChain("1")
-	if units1[0].Name != "beaconX-0@1.service" {
-		log.Fatalf("wrong unit name expected 'beaconX-0@1.service' got: %s", units1[0].Name)
+	if units1[0].Name != "nomi-0@1.service" {
+		log.Fatalf("wrong unit name expected 'nomi-0@1.service' got: %s", units1[0].Name)
 	}
 	options1 := units1[0].Options
 	if options1[1].Name != "ExecStart" && options1[1].Value != "/bin/sh -c 'sleep 90000'" {
@@ -24,10 +24,11 @@ func TestBuilder(t *testing.T) {
 	}
 
 	// check Docker configuration
-	builder, err = NewBuilder(app, 1, "127.0.0.1:54541", true, false)
+	app = definition.Application{Type: "docker"}
+	builder, err = NewBuilder(app, 1, "127.0.0.1:54541")
 	units2 := builder.MakeUnitChain("1")
-	if units2[0].Name != "beaconX-0@1.service" {
-		log.Fatalf("wrong unit name expected 'beaconX-0@1.service' got: %s", units2[0].Name)
+	if units2[0].Name != "nomi-0@1.service" {
+		log.Fatalf("wrong unit name expected 'nomi-0@1.service' got: %s", units2[0].Name)
 	}
 	options2 := units2[0].Options
 	if options2[1].Name != "ExecStartPre" && options2[1].Value != "-/bin/bash -c '/usr/bin/docker rm -f %p-%i'" {
@@ -35,10 +36,11 @@ func TestBuilder(t *testing.T) {
 	}
 
 	// check rkt configuration
-	builder, err = NewBuilder(app, 1, "127.0.0.1:54541", false, true)
+	app = definition.Application{Type: "rkt"}
+	builder, err = NewBuilder(app, 1, "127.0.0.1:54541")
 	units3 := builder.MakeUnitChain("1")
-	if units3[0].Name != "beaconX-0@1.service" {
-		log.Fatalf("wrong unit name expected 'beaconX-0@1.service' got: %s", units3[0].Name)
+	if units3[0].Name != "nomi-0@1.service" {
+		log.Fatalf("wrong unit name expected 'nomi-0@1.service' got: %s", units3[0].Name)
 	}
 	options3 := units3[0].Options
 	if options3[3].Name != "KillMode" && options3[3].Value != "Mixed" {

--- a/unit/engine.go
+++ b/unit/engine.go
@@ -274,7 +274,7 @@ func (e *UnitEngine) stopUnit(id string, state UnitState) {
 	newState.stopRequestTime = time.Now()
 
 	if Verbose {
-		log.Logger().Infof("marking beacon as to be deleted: %s", id)
+		log.Logger().Infof("marking unit as to be deleted: %s", id)
 	}
 	e.stoppingUnits[id] = newState
 	e.mu.Unlock()


### PR DESCRIPTION
There are too many cli arguments to offer different functionalities, deploy docker standard, deploy rkt standard container, deploy default shell unit, use a benchmark definition to deploy custom docker/rkt or unit file.

This PRs aims to unify the definition of custom benchmark applications. To do so, users should define their docker, rkt or systemd unit to be used for that purpose.

Therefore, the flags `use-rkt`, `use-docker` and `unitfile-service` dissappear. Their definition would be now done in `benchmark-file`. If no container image is specified for `rkt` and `docker` a by default docker image would be used (Alpine linux image `sleep ...`).
