### PR TITLE
fix typos in documents and comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![Go Report Card](https://goreportcard.com/badge/github.com/giantswarm/nomi)](https://goreportcard.com/report/github.com/giantswarm/nomi)
 [![IRC Channel](https://img.shields.io/badge/irc-%23giantswarm-blue.svg)](https://kiwiirc.com/client/irc.freenode.net/#giantswarm)
 
-**Nomi** is a benchmarking tool that tests a [fleet](https://github.com/coreos/fleet) cluster. With Nomi, you can deploy benchmark units that employ [Docker](https://github.com/docker/docker), [rkt](https://github.com/coreos/rkt) containers, or just raw `systemd` units. Fleemer is able to collect some metrics and generate some plots from those. To make use of Nomi, you just need to define your own benchmark using a YAML file. Nomi parses this file and runs the benchmark according to the instructions defined in it. Additionally, Nomi provides the possibility to define instructions in one line using the parameter `raw-instructions`.
+**Nomi** is a benchmarking tool that tests a [fleet](https://github.com/coreos/fleet) cluster. With Nomi, you can deploy benchmark units that employ [Docker](https://github.com/docker/docker), [rkt](https://github.com/coreos/rkt) containers, or just raw `systemd` units. Nomi is able to collect some metrics and generate some plots from those. To make use of Nomi, you just need to define your own benchmark using a YAML file. Nomi parses this file and runs the benchmark according to the instructions defined in it. Additionally, Nomi provides the possibility to define instructions in one line using the parameter `raw-instructions`.
 
 ## Requirements
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -149,7 +149,7 @@ $ docker run -ti \
     --net=host \
     --pid=host \
     giantswarm/nomi:latest run \
-    --addr=192.68.10.101:54541 \
+    --addr=192.168.10.101:54541 \
     --generate-gnuplots \
     --raw-instructions="(sleep 1) (start 10 100) (sleep 60) (stop-all)"
 ```
@@ -196,8 +196,8 @@ $ docker run -ti \
   --net=host \
   --pid=host \
   giantswarm/nomi:latest run \
-  --addr=192.68.10.101:54541 \
-  --generate-plots \
+  --addr=192.168.10.101:54541 \
+  --generate-gnuplots \
   --raw-instructions="(sleep 1) (start 10 100) (sleep 60) (stop-all)"
 ```
 

--- a/log/logger.go
+++ b/log/logger.go
@@ -6,7 +6,7 @@ import (
 	"github.com/op/go-logging"
 )
 
-var log = logging.MustGetLogger("fleemer")
+var log = logging.MustGetLogger("nomi")
 
 func init() {
 	format := logging.MustStringFormatter(

--- a/unit/builder.go
+++ b/unit/builder.go
@@ -49,7 +49,7 @@ func (b *Builder) GetUnitPrefix() string {
 	return prefix
 }
 
-// MakeStatsDumper creates fleemer specific units to collect metrics in each host
+// MakeStatsDumper creates nomi specific units to collect metrics in each host
 func (b *Builder) MakeStatsDumper(name, cmd, statsEndpoint string) schema.Unit {
 	prefix := nomiUnitPrefix
 	if b.app.Name != "" {


### PR DESCRIPTION
- Change the old name `"fleemer"` to the new name `"nomi"`.
- Fix a wrong example with `"--generate-plots"` to `"--generate-gnuplots"`, also from `192.68.*` to `192.168.*`.
